### PR TITLE
Harden .gitignore to prevent committing .env secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,7 +136,13 @@ celerybeat.pid
 *.sage.py
 
 # Environments
+# Never commit secrets in .env files (matches .env at any depth, plus
+# variants like .env.local / .env.production). Keep committable templates.
 .env
+.env.*
+!.env.example
+!.env.sample
+!.env.template
 .envrc
 .venv
 env/
@@ -206,3 +212,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# mac related temp files
+.DS_Store


### PR DESCRIPTION
## Summary
- Add `.env.*` to `.gitignore` so env-variant files (`.env.local`, `.env.production`, `.env.development`, …) are ignored at any depth.
- Keep committable templates via negation: `!.env.example`, `!.env.sample`, `!.env.template`.
- Add a `.DS_Store` ignore entry under a "mac related temp files" section.

## Why
The previous bare `.env` rule only matched files named exactly `.env`. Suffixed variants could still be committed accidentally, risking secret leakage.

## Verification
- `git check-ignore` confirms `.env`, `.env.local`, `.env.production`, and nested `.env.dev` are ignored.
- Templates `.env.example` / `.env.sample` / `.env.template` remain committable.
- No `.env*` file is currently tracked.