### PR TITLE
Reference hunk-swe extension in root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Quick links:
 - [Gemini CLI Automation](./README_GEMINI.md)
 - [MCP Support](progctx-mcp/)
 
+## Hunk-SWE (SWE-bench Extension)
+[`hunk-swe/`](hunk-swe/) is the SWE-bench counterpart of this study: the 32 multi-hunk bugs from SWE-bench Verified, the four agent runners (with MCP variants), the shared Docker-isolated harness, and the hunk-divergence / proximity-class analysis and metrics. See [`hunk-swe/README.md`](hunk-swe/README.md). Its MCP code-search server lives in [`progctx-mcp-swe-bench/`](progctx-mcp-swe-bench/).
+
 ## Prompts
 - For vanilla Agent runs, the prompt is at [`agentic_ai/prompt.md`](agentic_ai/prompt.md)
 - For MCP Agent runs, the prompt is at [`agentic_ai/prompt_mcp.md`](agentic_ai/prompt_mcp.md)


### PR DESCRIPTION
## Summary
Adds a short section to the root `README.md` linking the SWE-bench extension (`hunk-swe/`) and its companion MCP code-search server (`progctx-mcp-swe-bench/`). Both were merged recently but not yet referenced from the top-level README.

## Change
One new section ("Hunk-SWE (SWE-bench Extension)") with links to `hunk-swe/`, `hunk-swe/README.md`, and `progctx-mcp-swe-bench/`. No other content changed.